### PR TITLE
request: add client files for tians-testing-idir-only-with-team-2-5150

### DIFF
--- a/terraform/keycloak-dev/realms/onestopauth/client-tians-testing-idir-only-with-team-2-5150.tf
+++ b/terraform/keycloak-dev/realms/onestopauth/client-tians-testing-idir-only-with-team-2-5150.tf
@@ -1,0 +1,15 @@
+module "client_tians-testing-idir-only-with-team-2-5150" {
+  source      = "github.com/bcgov/sso-terraform-keycloak-client?ref=dev"
+  realm_id    = data.keycloak_realm.this.id
+  client_name = "tians-testing-idir-only-with-team-2-5150"
+  valid_redirect_uris = [
+    "https://example"
+  ]
+  description                = "CSS App Created"
+  access_type                = "PUBLIC"
+  pkce_code_challenge_method = "S256"
+  web_origins = [
+    "https://example",
+    "+"
+  ]
+}

--- a/terraform/keycloak-prod/realms/onestopauth/client-tians-testing-idir-only-with-team-2-5150.tf
+++ b/terraform/keycloak-prod/realms/onestopauth/client-tians-testing-idir-only-with-team-2-5150.tf
@@ -1,0 +1,15 @@
+module "client_tians-testing-idir-only-with-team-2-5150" {
+  source      = "github.com/bcgov/sso-terraform-keycloak-client?ref=dev"
+  realm_id    = data.keycloak_realm.this.id
+  client_name = "tians-testing-idir-only-with-team-2-5150"
+  valid_redirect_uris = [
+    "https://example"
+  ]
+  description                = "CSS App Created"
+  access_type                = "PUBLIC"
+  pkce_code_challenge_method = "S256"
+  web_origins = [
+    "https://example",
+    "+"
+  ]
+}

--- a/terraform/keycloak-test/realms/onestopauth/client-tians-testing-idir-only-with-team-2-5150.tf
+++ b/terraform/keycloak-test/realms/onestopauth/client-tians-testing-idir-only-with-team-2-5150.tf
@@ -1,0 +1,15 @@
+module "client_tians-testing-idir-only-with-team-2-5150" {
+  source      = "github.com/bcgov/sso-terraform-keycloak-client?ref=dev"
+  realm_id    = data.keycloak_realm.this.id
+  client_name = "tians-testing-idir-only-with-team-2-5150"
+  valid_redirect_uris = [
+    "https://example"
+  ]
+  description                = "CSS App Created"
+  access_type                = "PUBLIC"
+  pkce_code_challenge_method = "S256"
+  web_origins = [
+    "https://example",
+    "+"
+  ]
+}


### PR DESCRIPTION

  #### Project Name: `Tians Testing Idir Only With Team 2 5150`
  #### Target Realm: `onestopauth`
  #### Environments: `dev, test, prod`
  <details><summary>Show Details for dev</summary>
  ```<ul>✔️Valid Redirect Urls<li>https://example</li></ul>```
  </details>,<details><summary>Show Details for test</summary>
  ```<ul>✔️Valid Redirect Urls<li>https://example</li></ul>```
  </details>,<details><summary>Show Details for prod</summary>
  ```<ul>✔️Valid Redirect Urls<li>https://example</li></ul>```
  </details>