### PR TITLE
request: add client files for jaffer-first-test-25-mar-7063

### DIFF
--- a/terraform/keycloak-dev/realms/onestopauth-both/client-jaffer-first-test-25-mar-7063.tf
+++ b/terraform/keycloak-dev/realms/onestopauth-both/client-jaffer-first-test-25-mar-7063.tf
@@ -1,0 +1,15 @@
+module "client_jaffer-first-test-25-mar-7063" {
+  source      = "github.com/bcgov/sso-terraform-keycloak-client?ref=dev"
+  realm_id    = data.keycloak_realm.this.id
+  client_name = "jaffer-first-test-25-mar-7063"
+  valid_redirect_uris = [
+    "https://localhost:8000"
+  ]
+  description                = "CSS App Created"
+  access_type                = "PUBLIC"
+  pkce_code_challenge_method = "S256"
+  web_origins = [
+    "https://localhost:8000",
+    "+"
+  ]
+}

--- a/terraform/keycloak-test/realms/onestopauth-both/client-jaffer-first-test-25-mar-7063.tf
+++ b/terraform/keycloak-test/realms/onestopauth-both/client-jaffer-first-test-25-mar-7063.tf
@@ -1,0 +1,15 @@
+module "client_jaffer-first-test-25-mar-7063" {
+  source      = "github.com/bcgov/sso-terraform-keycloak-client?ref=dev"
+  realm_id    = data.keycloak_realm.this.id
+  client_name = "jaffer-first-test-25-mar-7063"
+  valid_redirect_uris = [
+    "https://localhost:8000"
+  ]
+  description                = "CSS App Created"
+  access_type                = "PUBLIC"
+  pkce_code_challenge_method = "S256"
+  web_origins = [
+    "https://localhost:8000",
+    "+"
+  ]
+}


### PR DESCRIPTION

  #### Project Name: `Jaffer First Test 25 Mar 7063`
  #### Target Realm: `onestopauth-both`
  #### Environments: `dev, test`
  <details><summary>Show Details for dev</summary>
  ```<ul>✔️Valid Redirect Urls<li>https://localhost:8000</li></ul>```
  </details>,<details><summary>Show Details for test</summary>
  ```<ul>✔️Valid Redirect Urls<li>https://localhost:8000</li></ul>```
  </details>