### PR TITLE
request: add client files for versatile-neutral-success-9036

### DIFF
--- a/terraform-v2/keycloak-dev/standard-clients/versatile-neutral-success-9036.tf
+++ b/terraform-v2/keycloak-dev/standard-clients/versatile-neutral-success-9036.tf
@@ -1,0 +1,31 @@
+module "versatile-neutral-success-9036" {
+  source                              = "github.com/bcgov/sso-terraform-modules?ref=dev/modules/standard-client"
+  realm_id                            = var.standard_realm_id
+  client_id                           = "versatile-neutral-success-9036"
+  client_name                         = "Versatile neutral success"
+  access_token_lifespan               = ""
+  client_session_idle_timeout         = ""
+  client_session_max_lifespan         = ""
+  client_offline_session_idle_timeout = ""
+  client_offline_session_max_lifespan = ""
+  idps = [
+    "idir",
+    "common"
+  ]
+  description                  = "CSS App Created"
+  additional_role_attribute    = ""
+  login_theme                  = ""
+  override_authentication_flow = true
+  browser_authentication_flow  = data.keycloak_authentication_flow.idp_stopper.id
+  access_type                  = "PUBLIC"
+  pkce_code_challenge_method   = "S256"
+  web_origins = [
+    "http://moist-town.com",
+    "+"
+  ]
+  standard_flow_enabled    = true
+  service_accounts_enabled = false
+  valid_redirect_uris = [
+    "http://moist-town.com"
+  ]
+}


### PR DESCRIPTION
#### Project Name: `Versatile neutral success`
  #### Client Id: `versatile-neutral-success-9036`
  #### Target Realm: `standard`
  #### Submitted by: `Pathfinder SSO Training`
  #### Accountable Person/Team: `Roland and Training Account`
  #### Environments: `dev`
  #### Identity providers: `idir`
  
<details>
  <summary>Show Details for dev</summary>
  <ul>✔️ Valid Redirect Urls<li>http://moist-town.com</li>
  </ul>
</details>