### PR TITLE
feat: automated branch pruning

### DIFF
--- a/.github/workflows/prune-branches.yaml
+++ b/.github/workflows/prune-branches.yaml
@@ -17,10 +17,10 @@ jobs:
     name: Remove Stale Branches
     runs-on: ubuntu-latest
     steps:
-      - uses: fpicalausa/remove-stale-branches@f442973cf98f499d7d13c7e274c62d87fbaedc39
-        with:
-          dry-run: ${{ github.event.inputs.dry_run }} 
-          exempt-branches-regex: (master|main|dev)
-          days-before-branch-delete: ${{ github.event.inputs.days_before_branch_delete }}
-          days-before-branch-stale: 30
-          operations-per-run: ${{ github.event.inputs.operations_per_run }}
+    - uses: fpicalausa/remove-stale-branches@f442973cf98f499d7d13c7e274c62d87fbaedc39
+      with:
+        dry-run: ${{ github.event.inputs.dry_run }}
+        exempt-branches-regex: (master|main|dev)
+        days-before-branch-delete: ${{ github.event.inputs.days_before_branch_delete }}
+        days-before-branch-stale: 30
+        operations-per-run: ${{ github.event.inputs.operations_per_run }}

--- a/.github/workflows/prune-branches.yaml
+++ b/.github/workflows/prune-branches.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: fpicalausa/remove-stale-branches@f442973cf98f499d7d13c7e274c62d87fbaedc39
         with:
           dry-run: ${{ github.event.inputs.dry_run }} 
-          exempt-branches-regex: (auth|master|main|dev)
+          exempt-branches-regex: (master|main|dev)
           days-before-branch-delete: ${{ github.event.inputs.days_before_branch_delete }}
           days-before-branch-stale: 30
           operations-per-run: ${{ github.event.inputs.operations_per_run }}

--- a/.github/workflows/prune-branches.yaml
+++ b/.github/workflows/prune-branches.yaml
@@ -1,0 +1,26 @@
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        default: true
+        type: boolean
+        description: See output without deleting
+      days_before_branch_delete:
+        default: 7
+        description: Days to wait before deletion
+      operations_per_run:
+        default: 10
+        description: Maximum branch deletions
+
+jobs:
+  remove-stale-branches:
+    name: Remove Stale Branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@f442973cf98f499d7d13c7e274c62d87fbaedc39
+        with:
+          dry-run: ${{ github.event.inputs.dry_run }} 
+          exempt-branches-regex: (auth|master|main|dev)
+          days-before-branch-delete: ${{ github.event.inputs.days_before_branch_delete }}
+          days-before-branch-stale: 30
+          operations-per-run: ${{ github.event.inputs.operations_per_run }}


### PR DESCRIPTION
add action to prune branches. I found a good community action for this, I've locked it at the commit hash for security. I figure we can run this on a cron if we are happy with it so this is fully automated going forward. Right now it is on dispatch, I have tested it out on a personal repo and it looks good, there is also a nice dry-run option to see what will be cleared before doing anything.